### PR TITLE
Prevent running after update callbacks when creating new WebFlow item

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,5 +33,8 @@ jobs:
           PGUSER: postgres
           RAILS_ENV: test
 
+      - name: Run style check
+        run: bundle exec rails style
+
       - name: Run tests
         run: bundle exec rspec

--- a/lib/webflow_sync/configuration.rb
+++ b/lib/webflow_sync/configuration.rb
@@ -18,7 +18,8 @@ module WebflowSync
   end
 
   class Configuration
-    attr_accessor :api_token, :skip_webflow_sync, :webflow_site_id
+    attr_accessor :skip_webflow_sync, :webflow_site_id
+    attr_reader :api_token
 
     def api_token=(value)
       @api_token = Webflow.config.api_token = value

--- a/lib/webflow_sync/version.rb
+++ b/lib/webflow_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebflowSync
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end


### PR DESCRIPTION
This PR makes sure that `update_item` is not unnecessarily called right after `create_item` because we update the record
by setting `webflow_item_id`.