### PR TITLE
Reuse WebFlow HTTP connection when possible

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    webflow_sync (0.2.0)
+    webflow_sync (0.2.2)
       rails (>= 5.0)
       webflow-ruby
 

--- a/app/jobs/webflow_sync/initial_sync_job.rb
+++ b/app/jobs/webflow_sync/initial_sync_job.rb
@@ -7,8 +7,18 @@ module WebflowSync
       model_class.where(webflow_item_id: nil).find_each do |record|
         next if record.webflow_site_id.blank?
 
-        WebflowSync::Api.new(record.webflow_site_id).create_item(record, collection_slug)
+        client(record.webflow_site_id).create_item(record, collection_slug)
       end
     end
+
+    private
+
+      def client(site_id)
+        if @client&.site_id == site_id
+          @client
+        else
+          @client = WebflowSync::Api.new(site_id)
+        end
+      end
   end
 end

--- a/lib/webflow_sync/version.rb
+++ b/lib/webflow_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebflowSync
-  VERSION = '0.2.1'
+  VERSION = '0.2.2'
 end


### PR DESCRIPTION
This PR keeps around the Webflow::Client instance when possible.
This allows for faster API calls.