### PR TITLE
Add methods: get_all_items, publish; Sync slug if 'sync_webflow_slug' is true

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,7 +14,7 @@ GIT
 PATH
   remote: .
   specs:
-    webflow_sync (1.1.0)
+    webflow_sync (2.0.0)
       rails (>= 5.0)
       webflow-ruby
 
@@ -122,12 +122,12 @@ GEM
       guard-compat (~> 1.1)
       rspec (>= 2.99.0, < 4.0)
     hashdiff (1.0.1)
-    http (5.0.0)
+    http (5.0.1)
       addressable (~> 2.3)
       http-cookie (~> 1.0)
       http-form_data (~> 2.2)
-      llhttp-ffi (~> 0.0.1)
-    http-cookie (1.0.3)
+      llhttp-ffi (~> 0.3.0)
+    http-cookie (1.0.4)
       domain_name (~> 0.5)
     http-form_data (2.3.0)
     i18n (1.8.10)
@@ -135,7 +135,7 @@ GEM
     listen (3.5.1)
       rb-fsevent (~> 0.10, >= 0.10.3)
       rb-inotify (~> 0.9, >= 0.9.10)
-    llhttp-ffi (0.0.1)
+    llhttp-ffi (0.3.1)
       ffi-compiler (~> 1.0)
       rake (~> 13.0)
     loofah (2.9.1)
@@ -271,7 +271,7 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    websocket-driver (0.7.4)
+    websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.4.2)
@@ -293,4 +293,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.2.11
+   2.2.19

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -277,6 +277,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-18
   x86_64-darwin-19
   x86_64-linux
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,34 @@ Run API token Rails generator and follow instructions:
 ```bash
 bundle exec rails generate webflow_sync:api_token_flow
 ```
+### Configuration options
+
+In `config/initializers/webflow_sync.rb` you can specify configuration options:
+
+1. `api_token`
+2. `webflow_site_id`
+3. `skip_webflow_sync` - skip synchronization for different environments
+4. `sync_webflow_slug` - save slug generated on WebFlow to the Rails database, in the Rails model column. 
+
+  This can be useful if you want to link to WebFlow item directly from your Rails app:
+
+  ```rb
+  link_to('View on site', "https://#{webflow_domain}/articles/#{record.webflow_slug}", target: :blank)
+  ```
+
+  To save slug generated on WebFlow in Rails model, `webflow_slug` column:
+
+  1. add `webflow_slug` column on the model table, then
+  2. set the `sync_webflow_slug` option to `true`.
+
+  Example: 
+
+  ```rb
+  WebflowSync.configure do |config|
+    config.skip_webflow_sync = ActiveModel::Type::Boolean.new.cast(ENV.fetch('SKIP_WEBFLOW_SYNC'))
+    config.sync_webflow_slug = ActiveModel::Type::Boolean.new.cast(ENV.fetch('SYNC_WEBFLOW_SLUG'))
+  end
+  ```
 
 ### Add WebflowSync to models
 

--- a/app/services/webflow_sync/api.rb
+++ b/app/services/webflow_sync/api.rb
@@ -8,6 +8,29 @@ module WebflowSync
       @site_id = site_id
     end
 
+    def get_all_items(collection_slug:, page_limit: 100) # rubocop:disable Metrics/MethodLength
+      collection_id = find_webflow_collection(collection_slug)['_id']
+      max_items_per_page = page_limit # Webflow::Error: 'limit' must be less than or equal to 100
+      first_page_number = 1
+
+      result = make_request(:paginate_items, collection_id, page: first_page_number, per_page: max_items_per_page)
+      puts "Get all items from WebFlow for #{collection_slug} page: #{first_page_number}"
+
+      total_items = result['total']
+      total_pages = (total_items.to_f / max_items_per_page).ceil
+      items = result['items']
+
+      (2..total_pages).each do |page_number|
+        next_page_items = make_request(:paginate_items, collection_id,
+                                       page: page_number, per_page: max_items_per_page)['items']
+        puts "Get all items from WebFlow for #{collection_slug} page: #{page_number}"
+
+        items.concat next_page_items
+      end
+
+      items
+    end
+
     def get_item(collection_slug, webflow_item_id)
       collection = find_webflow_collection(collection_slug)
 

--- a/app/services/webflow_sync/api.rb
+++ b/app/services/webflow_sync/api.rb
@@ -63,9 +63,8 @@ module WebflowSync
     def delete_item(collection_slug, webflow_item_id)
       collection = find_webflow_collection(collection_slug)
       response = make_request(:delete_item, { '_cid' => collection['_id'], '_id' => webflow_item_id })
-      # When record is deleted from application, item is removed from Webflow collection, but item's page stay on live Webflow site.
-      # We need to trigger publish of all website domains in order this changes to be visible,
-      # and the item's page to be removed too.
+      # When the item is removed from WebFlow, it's still visible throughout the WebFlow site (probably due to some caching).
+      # To remove the item immediately from the WebFlow site, we need to publish the site.
       publish
 
       puts "Deleted #{webflow_item_id} from #{collection_slug}"

--- a/app/services/webflow_sync/api.rb
+++ b/app/services/webflow_sync/api.rb
@@ -68,6 +68,13 @@ module WebflowSync
       response
     end
 
+    def publish
+      response = make_request(:publish, site_id, domain_names: domain_names)
+
+      puts "Publish all domains for Webflow site with id: #{site_id}"
+      response
+    end
+
     private
 
       def client
@@ -76,6 +83,22 @@ module WebflowSync
 
       def collections
         @collections ||= client.collections(site_id)
+      end
+
+      def domain_names
+        @domain_names ||= find_domain_names
+      end
+
+      def find_domain_names
+        # client.domains request does not return the default domain
+        # We need to get default domain name if there are no custom domains set to avoid error:
+        # Webflow::Error: Domain not found for site
+        site = client.site(site_id)
+        default_domain_name = "#{site['shortName']}.webflow.io"
+        names = [default_domain_name]
+        client.domains(site_id).each { |domain| names << domain['name'] }
+
+        names
       end
 
       def find_webflow_collection(collection_slug)

--- a/app/services/webflow_sync/api.rb
+++ b/app/services/webflow_sync/api.rb
@@ -10,15 +10,14 @@ module WebflowSync
 
     def get_item(collection_slug, webflow_item_id)
       collection = find_webflow_collection(collection_slug)
-      client.item(collection['_id'], webflow_item_id)
+
+      make_request(:item, collection['_id'], webflow_item_id)
     end
 
-    def create_item(record, collection_slug) # rubocop:disable Metrics/MethodLength
+    def create_item(record, collection_slug)
       collection = find_webflow_collection(collection_slug)
-      response = client.create_item(
-        collection['_id'],
-        record.as_webflow_json.reverse_merge(_archived: false, _draft: false), live: true
-      )
+      response = make_request(:create_item, collection['_id'],
+                              record.as_webflow_json.reverse_merge(_archived: false, _draft: false), live: true)
 
       # use update_column to skip callbacks to prevent WebflowSync::ItemSync to kick off
       if record.update_column(:webflow_item_id, response['_id']) # rubocop:disable Rails/SkipsModelValidations
@@ -32,17 +31,16 @@ module WebflowSync
 
     def update_item(record, collection_slug)
       collection = find_webflow_collection(collection_slug)
-      response = client.update_item(
-        { '_cid' => collection['_id'], '_id' => record.webflow_item_id },
-        record.as_webflow_json.reverse_merge(_archived: false, _draft: false), live: true
-      )
+      response = make_request(:update_item, { '_cid' => collection['_id'], '_id' => record.webflow_item_id },
+                              record.as_webflow_json.reverse_merge(_archived: false, _draft: false), live: true)
+
       puts "Updated #{record.inspect} in #{collection_slug}"
       response
     end
 
     def delete_item(collection_slug, webflow_item_id)
       collection = find_webflow_collection(collection_slug)
-      response = client.delete_item({ '_cid' => collection['_id'], '_id' => webflow_item_id })
+      response = make_request(:delete_item, { '_cid' => collection['_id'], '_id' => webflow_item_id })
       puts "Deleted #{webflow_item_id} from #{collection_slug}"
       response
     end
@@ -62,6 +60,20 @@ module WebflowSync
         raise "Cannot find collection #{collection_slug} for Webflow site #{site_id}" unless response
 
         response
+      end
+
+      def make_request(method_name, *args, retries: 0, **kwargs)
+        if kwargs.present?
+          client.public_send(method_name, *args, **kwargs)
+        else
+          client.public_send(method_name, *args)
+        end
+      rescue Webflow::Error => e
+        raise if retries >= 8 || e.message.strip != 'Rate limit hit'
+
+        puts "Sleeping #{2**retries} seconds"
+        sleep 2**retries
+        make_request(method_name, *args, retries: retries + 1, **kwargs)
       end
   end
 end

--- a/app/services/webflow_sync/api.rb
+++ b/app/services/webflow_sync/api.rb
@@ -64,6 +64,11 @@ module WebflowSync
     def delete_item(collection_slug, webflow_item_id)
       collection = find_webflow_collection(collection_slug)
       response = make_request(:delete_item, { '_cid' => collection['_id'], '_id' => webflow_item_id })
+      # When record is deleted from application, item is removed from Webflow collection, but item's page stay on live Webflow site.
+      # We need to trigger publish of all website domains in order this changes to be visible,
+      # and the item's page to be removed too.
+      publish
+
       puts "Deleted #{webflow_item_id} from #{collection_slug}"
       response
     end

--- a/lib/generators/webflow_sync/templates/webflow_sync.rb
+++ b/lib/generators/webflow_sync/templates/webflow_sync.rb
@@ -4,4 +4,5 @@ WebflowSync.configure do |config|
   # config.api_token = ENV.fetch('WEBFLOW_API_TOKEN')
   # config.skip_webflow_sync = Rails.env.test? # default
   config.webflow_site_id = ENV.fetch('WEBFLOW_SITE_ID')
+  config.sync_webflow_slug = ENV.fetch('SYNC_WEBFLOW_SLUG')
 end

--- a/lib/webflow_sync/configuration.rb
+++ b/lib/webflow_sync/configuration.rb
@@ -18,7 +18,7 @@ module WebflowSync
   end
 
   class Configuration
-    attr_accessor :skip_webflow_sync, :webflow_site_id
+    attr_accessor :skip_webflow_sync, :webflow_site_id, :sync_webflow_slug
     attr_reader :api_token
 
     def api_token=(value)

--- a/lib/webflow_sync/version.rb
+++ b/lib/webflow_sync/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module WebflowSync
-  VERSION = '1.1.0'
+  VERSION = '2.0.0'
 end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -25,11 +25,20 @@ module WebflowSync
     end
 
     context 'when sync_webflow_slug is true' do
-      it 'is true' do
+      before(:each) do
+        @sync_webflow_slug = WebflowSync.configuration.sync_webflow_slug
         WebflowSync.configure do |config|
           config.sync_webflow_slug = true
         end
+      end
 
+      after(:each) do
+        WebflowSync.configure do |config|
+          config.sync_webflow_slug = @sync_webflow_slug
+        end
+      end
+
+      it 'is true' do
         expect(WebflowSync.configuration.sync_webflow_slug).to be(true)
       end
     end

--- a/spec/configuration_spec.rb
+++ b/spec/configuration_spec.rb
@@ -23,5 +23,15 @@ module WebflowSync
         expect(WebflowSync.configuration.skip_webflow_sync).to be(true)
       end
     end
+
+    context 'when sync_webflow_slug is true' do
+      it 'is true' do
+        WebflowSync.configure do |config|
+          config.sync_webflow_slug = true
+        end
+
+        expect(WebflowSync.configuration.sync_webflow_slug).to be(true)
+      end
+    end
   end
 end

--- a/spec/dummy/db/migrate/20210628200012_add_webflow_slug_to_articles.rb
+++ b/spec/dummy/db/migrate/20210628200012_add_webflow_slug_to_articles.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddWebflowSlugToArticles < ActiveRecord::Migration[6.1]
+  def change
+    add_column :articles, :webflow_slug, :string
+  end
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -4,15 +4,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_210_129_091_040) do
+ActiveRecord::Schema.define(version: 20_210_628_200_012) do
   create_table 'articles', force: :cascade do |t|
     t.string 'title'
     t.text 'description'
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 20_210_129_091_040) do
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.string 'webflow_item_id'
+    t.string 'webflow_slug'
     t.index ['published_at'], name: 'index_articles_on_published_at'
   end
 end

--- a/spec/jobs/webflow_sync/create_item_job_spec.rb
+++ b/spec/jobs/webflow_sync/create_item_job_spec.rb
@@ -49,5 +49,47 @@ module WebflowSync
 
       expect(article.reload.webflow_item_id).to be_present
     end
+
+    context 'when sync_webflow_slug is true' do
+      before(:each) do
+        @sync_webflow_slug = WebflowSync.configuration.sync_webflow_slug
+        WebflowSync.configure do |config|
+          config.sync_webflow_slug = true
+        end
+      end
+
+      after(:each) do
+        WebflowSync.configure do |config|
+          config.sync_webflow_slug = @sync_webflow_slug
+        end
+      end
+
+      it 'syncs webflow_slug', vcr: { cassette_name: 'webflow/create_item' } do
+        WebflowSync::CreateItemJob.perform_now(collection_slug, article.id)
+
+        expect(article.reload.webflow_slug).to be_present
+      end
+    end
+
+    context 'when sync_webflow_slug is false' do
+      before(:each) do
+        @sync_webflow_slug = WebflowSync.configuration.sync_webflow_slug
+        WebflowSync.configure do |config|
+          config.sync_webflow_slug = false
+        end
+      end
+
+      after(:each) do
+        WebflowSync.configure do |config|
+          config.sync_webflow_slug = @sync_webflow_slug
+        end
+      end
+
+      it 'does not sync webflow slug', vcr: { cassette_name: 'webflow/create_item' } do
+        WebflowSync::CreateItemJob.perform_now(collection_slug, article.id)
+
+        expect(article.reload.webflow_slug).to be_nil
+      end
+    end
   end
 end

--- a/spec/jobs/webflow_sync/destroy_item_job_spec.rb
+++ b/spec/jobs/webflow_sync/destroy_item_job_spec.rb
@@ -31,11 +31,18 @@ module WebflowSync
       end
     end
 
-    it 'destroys item on Webflow', vcr: { cassette_name: 'webflow/delete_item' } do
+    # it 'destroys item on Webflow', vcr: { cassette_name: 'webflow/delete_item' } do
+    #   result = WebflowSync::DestroyItemJob.perform_now(collection_slug: 'articles',
+    #                                                    webflow_site_id: 'webflow_site_id',
+    #                                                    webflow_item_id: 'webflow_item_id')
+    #   expect(result).to eq({ 'deleted' => 1 })
+    # end
+    it 'destroys item on Webflow', vcr: { cassette_name: 'webflow/delete_item_and_publish' } do
       result = WebflowSync::DestroyItemJob.perform_now(collection_slug: 'articles',
-                                                       webflow_site_id: 'webflow_site_id',
-                                                       webflow_item_id: 'webflow_item_id')
-      expect(result).to eq({ 'deleted' => 1 })
+                                                       webflow_site_id: '6048c57f255aff50533565bf',
+                                                       webflow_item_id: '60ba0e078987c80f387d83c8')
+      # We should get number of items deleted, but we get {} in response event item is removed from collection.
+      expect(result).to eq({ 'deleted' => {} })
     end
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -53,7 +53,7 @@ RSpec.configure do |config|
   #   # is tagged with `:focus`, all examples get run. RSpec also provides
   #   # aliases for `it`, `describe`, and `context` that include `:focus`
   #   # metadata: `fit`, `fdescribe` and `fcontext`, respectively.
-  #   config.filter_run_when_matching :focus
+  config.filter_run_when_matching :focus
   #
   #   # Allows RSpec to persist some state between runs in order to support
   #   # the `--only-failures` and `--next-failure` CLI options. We recommend

--- a/spec/vcr/webflow/delete_item_and_publish.yml
+++ b/spec/vcr/webflow/delete_item_and_publish.yml
@@ -1,0 +1,226 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: https://api.webflow.com/sites/6048c57f255aff50533565bf/collections
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <WEBFLOW_API_TOKEN>
+      Accept-Version:
+      - 1.0.0
+      Connection:
+      - close
+      Host:
+      - api.webflow.com
+      User-Agent:
+      - http.rb/5.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 04 Jun 2021 11:27:47 GMT
+      Etag:
+      - W/"arMfhBv634SfndyDOD0h8A=="
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '59'
+      X-Response-Time:
+      - 49.017ms
+      X-Wf-Rid:
+      - 0fb8152c-2e76-436f-a463-925efd51adef
+      Content-Length:
+      - '1737'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '[{"_id":"6048c57f255aff31be3565cb","lastUpdated":"2021-03-10T13:11:33.700Z","createdOn":"2021-01-22T20:05:10.724Z","name":"Forms","slug":"forms","singularName":"Form"},{"_id":"6048c57f255aff370f3565ca","lastUpdated":"2021-03-10T13:11:33.690Z","createdOn":"2021-01-14T16:55:35.029Z","name":"FAQs","slug":"faqs","singularName":"FAQ"},{"_id":"6048c57f255aff41433565c9","lastUpdated":"2021-03-10T13:11:33.681Z","createdOn":"2021-01-12T01:50:06.685Z","name":"Events","slug":"events","singularName":"Event"},{"_id":"6048c57f255aff5fe43565c8","lastUpdated":"2021-04-27T08:29:21.155Z","createdOn":"2021-01-11T23:28:29.566Z","name":"Entities","slug":"entities","singularName":"Entity"},{"_id":"6048c57f255aff62883565cf","lastUpdated":"2021-03-10T13:11:33.734Z","createdOn":"2021-01-21T19:49:39.453Z","name":"Subpages","slug":"subpages","singularName":"Subpage"},{"_id":"6048c57f255aff7f4d3565cd","lastUpdated":"2021-04-27T08:29:33.678Z","createdOn":"2021-02-01T15:52:48.864Z","name":"People","slug":"people","singularName":"Person"},{"_id":"6048c57f255affa0233565ce","lastUpdated":"2021-03-10T13:11:33.724Z","createdOn":"2021-01-12T18:45:12.934Z","name":"Resources","slug":"resources","singularName":"Resource"},{"_id":"6048c57f255affa0983565c7","lastUpdated":"2021-03-11T08:56:11.231Z","createdOn":"2021-01-12T12:38:39.095Z","name":"Documents","slug":"documents","singularName":"Document"},{"_id":"6048c57f255affcd513565c5","lastUpdated":"2021-03-10T13:11:33.643Z","createdOn":"2021-02-01T14:50:21.169Z","name":"Articles","slug":"articles","singularName":"Article"},{"_id":"6048c57f255afff5e33565cc","lastUpdated":"2021-03-10T13:11:33.708Z","createdOn":"2021-01-11T23:30:54.346Z","name":"Locations","slug":"locations","singularName":"Location"}]'
+  recorded_at: Fri, 04 Jun 2021 11:27:47 GMT
+- request:
+    method: delete
+    uri: https://api.webflow.com/collections/6048c57f255affcd513565c5/items/60ba0e078987c80f387d83c8
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <WEBFLOW_API_TOKEN>
+      Accept-Version:
+      - 1.0.0
+      Connection:
+      - close
+      Host:
+      - api.webflow.com
+      User-Agent:
+      - http.rb/5.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 04 Jun 2021 11:27:48 GMT
+      Etag:
+      - W/"e-dad11a87"
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '58'
+      X-Response-Time:
+      - 282.495ms
+      X-Wf-Rid:
+      - eb947e66-ed8d-403b-9d2a-0855b02b1bec
+      Content-Length:
+      - '14'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '{"deleted":{}}'
+  recorded_at: Fri, 04 Jun 2021 11:27:48 GMT
+- request:
+    method: get
+    uri: https://api.webflow.com/sites/6048c57f255aff50533565bf
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <WEBFLOW_API_TOKEN>
+      Accept-Version:
+      - 1.0.0
+      Connection:
+      - close
+      Host:
+      - api.webflow.com
+      User-Agent:
+      - http.rb/5.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 04 Jun 2021 11:27:49 GMT
+      Etag:
+      - W/"16e-3833c5c7"
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '57'
+      X-Response-Time:
+      - 25.585ms
+      X-Wf-Rid:
+      - c212165f-1e13-487d-baae-1f66a2c70280
+      Content-Length:
+      - '366'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '{"_id":"6048c57f255aff50533565bf","createdOn":"2021-03-10T13:11:33.510Z","name":"Sampletown,
+        CT","shortName":"sampletown-ct","lastPublished":"2021-06-04T11:19:04.311Z","previewUrl":"https://screenshots.webflow.com/sites/6048c57f255aff50533565bf/20210604110538_ea4050e833f26b40f51fc9e43fe8b3c5.png","timezone":"America/New_York","database":"6048c57f255aff63f93565c2"}'
+  recorded_at: Fri, 04 Jun 2021 11:27:49 GMT
+- request:
+    method: get
+    uri: https://api.webflow.com/sites/6048c57f255aff50533565bf/domains
+    body:
+      encoding: UTF-8
+      string: ''
+    headers:
+      Authorization:
+      - Bearer <WEBFLOW_API_TOKEN>
+      Accept-Version:
+      - 1.0.0
+      Connection:
+      - close
+      Host:
+      - api.webflow.com
+      User-Agent:
+      - http.rb/5.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 04 Jun 2021 11:27:50 GMT
+      Etag:
+      - W/"2-d4cbb29"
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '56'
+      X-Response-Time:
+      - 33.347ms
+      X-Wf-Rid:
+      - 82918fe0-cf5e-4e4c-a15a-44eef5cc270e
+      Content-Length:
+      - '2'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: "[]"
+  recorded_at: Fri, 04 Jun 2021 11:27:50 GMT
+- request:
+    method: post
+    uri: https://api.webflow.com/sites/6048c57f255aff50533565bf/publish
+    body:
+      encoding: UTF-8
+      string: '{"domains":["sampletown-ct.webflow.io"]}'
+    headers:
+      Authorization:
+      - Bearer <WEBFLOW_API_TOKEN>
+      Accept-Version:
+      - 1.0.0
+      Connection:
+      - close
+      Content-Type:
+      - application/json; charset=UTF-8
+      Host:
+      - api.webflow.com
+      User-Agent:
+      - http.rb/5.0.0
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 04 Jun 2021 11:27:51 GMT
+      Etag:
+      - W/"f-dfef9497"
+      X-Ratelimit-Limit:
+      - '60'
+      X-Ratelimit-Remaining:
+      - '55'
+      X-Response-Time:
+      - 91.412ms
+      X-Wf-Rid:
+      - 61c1003f-c682-4386-b299-9df40101e16c
+      Content-Length:
+      - '15'
+      Connection:
+      - Close
+    body:
+      encoding: UTF-8
+      string: '{"queued":true}'
+  recorded_at: Fri, 04 Jun 2021 11:27:51 GMT
+recorded_with: VCR 6.0.0


### PR DESCRIPTION
Fix removing records from Webflow after is destroyed in the application. We need to republish all Webflow websites for this change to be visible.

Sync `webflow_slug` for records only if the application have `sync_webflow_slug` enabled:
```
WebflowSync.configure do |config|
 ....
  config.sync_webflow_slug = ActiveModel::Type::Boolean.new.cast(ENV.fetch('SYNC_WEBFLOW_SLUG'))
end
```