### PR TITLE
move collection_slug into model

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,6 +162,8 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
+    nokogiri (1.13.7-arm64-darwin)
+      racc (~> 1.4)
     nokogiri (1.13.7-x86_64-darwin)
       racc (~> 1.4)
     nokogiri (1.13.7-x86_64-linux)
@@ -290,6 +292,7 @@ GEM
     zeitwerk (2.6.0)
 
 PLATFORMS
+  arm64-darwin-21
   x86_64-darwin-18
   x86_64-darwin-19
   x86_64-darwin-20

--- a/app/jobs/webflow_sync/create_item_job.rb
+++ b/app/jobs/webflow_sync/create_item_job.rb
@@ -15,6 +15,8 @@ module WebflowSync
       record = model_class.find_by(id:)
       return if record.blank?
       return if record.webflow_site_id.blank?
+      # override collection_slug if it is passed as an argument
+      record.try(:collection_slug) ? collection_slug = record.collection_slug : collection_slug
 
       WebflowSync::Api.new(record.webflow_site_id).create_item(record, collection_slug)
     end

--- a/app/jobs/webflow_sync/create_item_job.rb
+++ b/app/jobs/webflow_sync/create_item_job.rb
@@ -10,13 +10,12 @@ module WebflowSync
     # model_name => Rails model that has webflow_site_id and webflow_item_id columns
     # collection_slug => slug of the WebFlow collection
     # model_name = 'articles'; id = article.id, collection_slug = 'stories'
-    def perform(model_name, id, collection_slug = model_name.underscore.dasherize.pluralize)
+    def perform(model_name, id, collection_slug = nil)
       model_class = model_name.underscore.classify.constantize
       record = model_class.find_by(id:)
       return if record.blank?
       return if record.webflow_site_id.blank?
-      # override collection_slug if it is passed as an argument
-      record.try(:collection_slug) ? collection_slug = record.collection_slug : collection_slug
+      collection_slug ||= record.try(:collection_slug) || model_name.underscore.dasherize.pluralize
 
       WebflowSync::Api.new(record.webflow_site_id).create_item(record, collection_slug)
     end

--- a/app/jobs/webflow_sync/update_item_job.rb
+++ b/app/jobs/webflow_sync/update_item_job.rb
@@ -11,8 +11,7 @@ module WebflowSync
       record = model_class.find_by(id:)
       return if record.blank?
       return if record.webflow_site_id.blank?
-      # override collection_slug if it is passed as an argument
-      record.try(:collection_slug) ? collection_slug = record.collection_slug : collection_slug
+      collection_slug ||= record.try(:collection_slug) || model_name.underscore.dasherize.pluralize
 
       return WebflowSync::CreateItemJob.perform_now(model_name, id, collection_slug) if record.webflow_item_id.blank?
 

--- a/app/jobs/webflow_sync/update_item_job.rb
+++ b/app/jobs/webflow_sync/update_item_job.rb
@@ -6,7 +6,7 @@ module WebflowSync
     # For collections that have spaces in their name, WebFlow sets slug by replacing space for "-".
     # 'JobListing'.underscore.dasherize.pluralize => 'job-listings'
     # 'job_listing'.underscore.dasherize.pluralize => 'job-listings'
-    def perform(model_name, id, collection_slug = model_name.underscore.dasherize.pluralize)
+    def perform(model_name, id, collection_slug = nil)
       model_class = model_name.underscore.classify.constantize
       record = model_class.find_by(id:)
       return if record.blank?

--- a/app/jobs/webflow_sync/update_item_job.rb
+++ b/app/jobs/webflow_sync/update_item_job.rb
@@ -11,6 +11,9 @@ module WebflowSync
       record = model_class.find_by(id:)
       return if record.blank?
       return if record.webflow_site_id.blank?
+      # override collection_slug if it is passed as an argument
+      record.try(:collection_slug) ? collection_slug = record.collection_slug : collection_slug
+
       return WebflowSync::CreateItemJob.perform_now(model_name, id, collection_slug) if record.webflow_item_id.blank?
 
       WebflowSync::Api.new(record.webflow_site_id).update_item(record, collection_slug)


### PR DESCRIPTION
Hey @vfonic,

I adding the `collection_slug` as an optional method similar to `webflow_site_id` so you can just override this in the model when the naming is different rather than having to do anything fancy. I kept it in the arguments for now.  Could be simplified further but I thought I'd check your thoughts on this.

Thanks